### PR TITLE
Read attributes from Tileserver; communicate to carto-style-renderer using a POST.

### DIFF
--- a/carto_renderer/service.py
+++ b/carto_renderer/service.py
@@ -215,14 +215,14 @@ class RenderHandler(BaseHandler):
                 host=self.style_host,
                 port=self.style_port)
 
-            tile = {
-                layer: [
-                    {
-                        'wkbs': base64.b64decode(feature['wkbs']),
-                        'attributes': json.loads(base64.b64decode(feature['attributes']))
-                    } for feature in features
-                ] for layer, features in geobody['tile'].items()
-            }
+            def buildFeature(feature):
+                return {
+                    'wkbs': base64.b64decode(feature['wkbs']),
+                    'attributes': json.loads(base64.b64decode(feature['attributes']))
+                }
+
+            tile = {layer: [buildFeature(feature) for feature in features]
+                    for layer, features in geobody['tile'].items()}
 
             def handle_response(response):
                 """


### PR DESCRIPTION
We modified the format of the payload that tileserver sends to `carto-renderer` to pass the attributes associated with each feature. We're unpacking that now, attaching it to Mapnik Features, and using it to build the Mapnik-rendered tile.

The payload communication between `carto-style-renderer` and `carto-renderer` became a larger bottleneck for us due to payload size. We added `POST` requests to `carto-style-renderer` and use that interface here.